### PR TITLE
Add infinite IEnumerable<T> / IEnumerator<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,34 @@
 [![Coverage](https://coveralls.io/repos/github/invio/Invio.Extensions.Linq/badge.svg?branch=master)](https://coveralls.io/github/invio/Invio.Extensions.Linq?branch=master)
 
 A collection of extension methods and helper classes for working with Linq.
+
+# Installation
+The latest version of this package is available on NuGet. To install, run the following command:
+
+```
+PM> Install-Package Invio.Extensions.Linq
+```
+
+## [Enumerable Extensions](src/Invio.Extensions.Linq/EnumerableExtensions.cs)
+
+### Infinite Enumerables & Enumerators
+
+There are two extension methods on `IEnumerable<T>` that allow a caller to easily enumerate over the original enumerable ad infinitum. These are as follows:
+
+1. **`GetInfiniteEnumerator()`** returns an `IEnumerator<T>` that, upon reaching the end of the parent `IEnumerable<T>`, will start again at the beginning.
+2. **`AsInfiniteEnumerable()`** makes the `IEnumerable<T>` parent no longer
+
+These can be especially useful in [generative or "model-based" testing scenarios](https://en.wikipedia.org/wiki/Model-based_testing) when you want to rotate through a collection of valid data as a parameter for as long as you have test cases.
+
+```csharp
+public static IEnumerable<Profile> ValidProfiles { get; } =
+    ImmutableList
+        .Create<Profile>(Profile.User, Profile.Admin)
+        .AsInfiniteEnumerable();
+
+public IEnumerable<TestCase> ToTestCases(IEnumerable<Guid> ids) {
+   return ids.Zip(ValidProfiles, (id, profile) => new TestCase(id, profile));
+}
+```
+
+In the above example, it does not matter how large `IEnumerable<Guid>` is, it will always get a valid `Profile` from the list of `ValidProfiles`.

--- a/src/Invio.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Invio.Extensions.Linq/EnumerableExtensions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Invio.Extensions.Linq {
+
+    /// <summary>
+    ///   Broad concepts that extend the <see cref="IEnumerable" /> and
+    ///   <see cref="IEnumerable{T}" /> functionality that is currently
+    ///   available within the System.* namespaces.
+    /// </summary>
+    public static class EnumerableExtensions {
+
+        /// <summary>
+        ///   Similar to <see cref="IEnumerable{T}.GetEnumerator" />, this
+        ///   method returns an <see cref="IEnumerator{T}" /> that iterates
+        ///   through all items, but instead of stopping at the end, it
+        ///   returns once again to the beginning..
+        /// </summary>
+        /// <remarks>
+        ///   The order in which the items will be returned will always
+        ///   be the order in which they currently exist within
+        ///   <paramref name="source" />.
+        /// </remarks>
+        /// <param name="source">
+        ///   The <see cref="IEnumerable{T}" /> that will be enumerated
+        ///   ad infinitum.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Lazily thrown when <paramref name="source" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   Lazily thrown when <paramref name="source" /> is empty.
+        /// </exception>
+        /// <returns>
+        ///   An <see cref="IEnumerator{T}" /> which will enumerate over all
+        ///   items in <paramref name="source" /> ad infinitum.
+        /// </returns>
+        public static IEnumerator<T> GetInfiniteEnumerator<T>(
+            this IEnumerable<T> source) {
+
+            return source.AsInfiniteEnumerable().GetEnumerator();
+        }
+
+        /// <summary>
+        ///   Similar to <see cref="Enumerable.AsEnumerable" />, this
+        ///   method returns an <see cref="IEnumerable{T}" /> that contains
+        ///   all of the items in <paramref name="source" />, but instead of
+        ///   stopping at the end of the original enumerable, it returns
+        ///   once again to the beginning.
+        /// </summary>
+        /// <remarks>
+        ///   The order in which the items will be returned will always
+        ///   be the order in which they currently exist within
+        ///   <paramref name="source" />, with the first item immediately
+        ///   following the last item.
+        /// </remarks>
+        /// <param name="source">
+        ///   The <see cref="IEnumerable{T}" /> that will be able to be
+        ///   enumerated ad infinitum.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Lazily thrown when <paramref name="source" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   Lazily thrown when <paramref name="source" /> is empty.
+        /// </exception>
+        /// <returns>
+        ///   An <see cref="IEnumerable{T}" /> which is able to enumerate
+        ///   over all items in <paramref name="source" /> ad infinitum.
+        /// </returns>
+        public static IEnumerable<T> AsInfiniteEnumerable<T>(
+            this IEnumerable<T> source) {
+
+            if (source == null) {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var enumerator = source.GetEnumerator();
+
+            while (true) {
+                if (!enumerator.MoveNext()) {
+                    enumerator = source.GetEnumerator();
+
+                    if (!enumerator.MoveNext()) {
+                        throw new ArgumentException(
+                            $"The enumerable provided is empty.",
+                            nameof(source)
+                        );
+                    }
+                }
+
+                yield return enumerator.Current;
+            }
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
+++ b/test/Invio.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Invio.Xunit;
+using Xunit;
+
+namespace Invio.Extensions.Linq {
+
+    [UnitTest]
+    public sealed class EnumerableExtensionsTests {
+
+        [Fact]
+        public void GetInfiniteEnumerator_NullSource() {
+
+            // Arrange
+
+            IEnumerable<object> enumerable = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => enumerable.GetInfiniteEnumerator().MoveNext()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void GetInfiniteEnumerator_EmptySource() {
+
+            // Arrange
+
+            var enumerable =
+                Enumerable
+                    .Empty<object>()
+                    .GetInfiniteEnumerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => enumerable.MoveNext()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+
+            Assert.Equal(
+                "The enumerable provided is empty." +
+                Environment.NewLine + "Parameter name: source",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void GetInfiniteEnumerator_EnumeratesEndlessly(int initialCount) {
+
+            // Arrange
+
+            const int numberOfLoops = 3;
+
+            IEnumerable<object> enumerable =
+                Enumerable
+                    .Range(0, initialCount)
+                    .Select(_ => new object())
+                    .ToList()
+                    .AsEnumerable();
+
+            var infiniteEnumerator = enumerable.GetInfiniteEnumerator();
+
+            // Act
+
+            var results = new List<object>();
+
+            while (infiniteEnumerator.MoveNext()) {
+                results.Add(infiniteEnumerator.Current);
+
+                if (results.Count == initialCount * numberOfLoops) {
+                    break;
+                }
+            }
+
+            // Assert
+
+            for (var loop = 0; loop < numberOfLoops; loop++) {
+                Assert.Equal(
+                    enumerable,
+                    results.Skip(loop * initialCount).Take(initialCount)
+                );
+            }
+        }
+
+        [Fact]
+        public void AsInfiniteEnumerable_NullSource() {
+
+            // Arrange
+
+            IEnumerable<object> enumerable = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => enumerable.AsInfiniteEnumerable().Take(1).ToList()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void AsInfiniteEnumerable_EmptySource() {
+
+            // Arrange
+
+            var enumerable =
+                Enumerable
+                    .Empty<object>()
+                    .AsInfiniteEnumerable();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => enumerable.Take(1).ToList()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+
+            Assert.Equal(
+                "The enumerable provided is empty." +
+                Environment.NewLine + "Parameter name: source",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void AsInfiniteEnumerable_EnumeratesEndlessly(int initialCount) {
+
+            // Arrange
+
+            const int numberOfLoops = 3;
+
+            IEnumerable<object> enumerable =
+                Enumerable
+                    .Range(0, initialCount)
+                    .Select(_ => new object())
+                    .ToList()
+                    .AsEnumerable();
+
+            var infiniteEnumerator =
+                enumerable
+                    .AsInfiniteEnumerable()
+                    .GetEnumerator();
+
+            // Act
+
+            var results = new List<object>();
+
+            while (infiniteEnumerator.MoveNext()) {
+                results.Add(infiniteEnumerator.Current);
+
+                if (results.Count == initialCount * numberOfLoops) {
+                    break;
+                }
+            }
+
+            // Assert
+
+            for (var loop = 0; loop < numberOfLoops; loop++) {
+                Assert.Equal(
+                    enumerable,
+                    results.Skip(loop * initialCount).Take(initialCount)
+                );
+            }
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Linq.Tests/Invio.Extensions.Linq.Tests.csproj
+++ b/test/Invio.Extensions.Linq.Tests/Invio.Extensions.Linq.Tests.csproj
@@ -5,9 +5,6 @@
     <AssemblyName>Invio.Extensions.Linq.Tests</AssemblyName>
     <PackageId>Invio.Extensions.Linq.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <AssetTargetFallback>
-      $(PackageTargetFallback);dotnet5.4;portable-net451+win8
-    </AssetTargetFallback>
     <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I'm using these when I have a collection of things I want to test and a collection of valid data that shouldn't affect the results. I original had it in our closed our under `Gambit.Documents.EnumerableExtensions`, but now I want it in more places, so I'm moving it here.

Thoughts?