### PR TITLE
Add IEnumerable<T>.Batch() extension method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In the above example, it does not matter how large the `IEnumerable<Guid>` is, i
 
 ### Enumerable Subsequences
 
-There is an extension method on `IEnumerable<T>` that allows allows a caller to get all
+There is an extension method on `IEnumerable<T>` that allows a caller to get all
 potential subsequences of an initial sequence of elements. Named **`Subsequences()`**,
 this method will include all combinations of elements in no particular order, including
 the identity sequence and the empty sequence.
@@ -65,4 +65,21 @@ public static void EnumerateSubsets() {
 [foo, biz]
 [bar, biz]
 [foo, bar, biz]
+```
+
+### Batching
+
+The `IEnumerable<T>.Batch(size)` extension method breaks the enumerable's items into batches of `IEnumerable<T>` where each batch contains `size` items, if possible.
+
+```csharp
+public static void EnumerateBatches() {
+    var values = new List<string> { "foo", "bar", "biz" };
+
+    foreach (var batch in values.Batch(size: 2)) {
+        Console.WriteLine("[" + String.Join(", ") + "]");
+    }
+}
+// Output
+[foo, bar]
+[biz]
 ```

--- a/src/Invio.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Invio.Extensions.Linq/EnumerableExtensions.cs
@@ -198,6 +198,63 @@ namespace Invio.Extensions.Linq {
             }
         }
 
+        /// <summary>
+        ///   Breaks an <see cref="IEnumerable{T}" /> into batches of <paramref name="size" />.
+        /// </summary>
+        /// <remarks>
+        ///   An empty <see cref="IEnumerable{T}" /> will return no batches. If the number
+        ///   of items in the source <see cref="IEnumerable{T}" /> is not perfectly
+        ///   divisible by <paramref name="size" />, the last batch will be smaller
+        ///   than <paramref name="size" />. The order of items in <paramref name="source" />
+        ///   is preserved.
+        /// </remarks>
+        /// <param name="source">
+        ///   The original sequence of elements that will be broken into batches.
+        /// </param>
+        /// <param name="size">
+        ///   The number of items that will be in each set.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="source" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="size" /> is not a positive integer.
+        /// </exception>
+        /// <returns>
+        ///   Zero ot more batches of <see cref="IEnumerable{T}" /> that will each contain
+        ///   up to <paramref name="size" /> items.
+        /// </returns>
+        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> source, int size) {
+            if (source == null) {
+                throw new ArgumentNullException(nameof(source));
+            } else if (size < 1) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(size),
+                    size,
+                    $"The '{nameof(size)}' must be a positive integer."
+                );
+            }
+
+            var batch = new T[size];
+            var index = 0;
+
+            foreach (var item in source) {
+                batch[index++] = item;
+
+                if (index == size) {
+                    yield return batch;
+
+                    batch = new T[size];
+                    index = 0;
+                }
+            }
+
+            if (index > 0) {
+                Array.Resize(ref batch, index);
+                yield return batch;
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
I wanted to do some batching of items in enumerables downstream. Here is an extension method so I can do that.