### PR TITLE
Add 'DistinctBy' extension to IEnumerable<T>

### DIFF
--- a/src/Invio.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Invio.Extensions.Linq/EnumerableExtensions.cs
@@ -309,7 +309,7 @@ namespace Invio.Extensions.Linq {
         /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="source" /> is null.
         /// </exception>
-        /// <exception cref="ArgumentNullException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="size" /> is not a positive integer.
         /// </exception>
         /// <returns>
@@ -345,6 +345,49 @@ namespace Invio.Extensions.Linq {
                 Array.Resize(ref batch, index);
                 yield return batch;
             }
+        }
+
+
+        /// <summary>
+        ///   Returns a distinct enumerable of <see cref="IEnumerable{TSource}" /> by using
+        ///   the default comparison on the type <typeparamref name="TKey" />.
+        /// </summary>
+        /// <typeparam name="TSource">
+        ///   The type of the items in <paramref name="source" /> that will be have
+        ///   a key extracted in order to determine a new distinct result of items.
+        /// </typeparam>
+        /// <typeparam name="TKey">
+        ///   A value that can be extracted from an instance of <typeparamref name ="TSource" />
+        ///   that will determine the distinctness of each item in <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///   The original sequence of elements that need to be filtered for distinct items.
+        /// </param>
+        /// <param name="keySelector">
+        ///   A delegate that will be invoked on each item with <paramref name="source" />,
+        ///   extract a value of type <typeparamref name="TKey" />. If two or more items
+        ///   within <paramref name="source" /> have the same key, only one will be returned.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="source" /> or <paramref name="keySelector" />
+        ///   is null.
+        /// </exception>
+        /// <returns>
+        ///   Each of the results that was determined distinct as determined by the values
+        ///   extracted from items in <paramref name="source" /> via key values returned
+        ///   from the <paramref name="keySelector" />.
+        /// </returns>
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector) {
+
+            if (source == null) {
+                throw new ArgumentNullException(nameof(source));
+            } else if (keySelector == null) {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+
+            return source.Distinct(new ProjectionEqualityComparer<TSource, TKey>(keySelector));
         }
 
     }

--- a/src/Invio.Extensions.Linq/KeyEqualityComparer.cs
+++ b/src/Invio.Extensions.Linq/KeyEqualityComparer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Invio.Extensions.Linq {
+
+    /// <summary>
+    ///   Converts a lambda into an implementation of <see cref="EqualityComparer{TSource}" />.
+    /// </summary>
+    internal class ProjectionEqualityComparer<TSource, TKey> : IEqualityComparer<TSource> {
+
+        private Func<TSource, TKey> projection { get; }
+        private IEqualityComparer<TKey> comparer { get; }
+
+        public ProjectionEqualityComparer(Func<TSource, TKey> projection) {
+            this.projection = projection;
+            this.comparer = EqualityComparer<TKey>.Default;
+        }
+
+        public int GetHashCode(TSource obj) {
+            if (obj == null) {
+                throw new ArgumentNullException("obj");
+            }
+
+            return this.comparer.GetHashCode(projection(obj));
+        }
+
+        public bool Equals(TSource x, TSource y) {
+            if (x == null || y == null) {
+                return x == null && y == null;
+            }
+            
+            return this.comparer.Equals(projection(x), projection(y));
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
+++ b/test/Invio.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
@@ -709,6 +709,160 @@ namespace Invio.Extensions.Linq {
             Assert.Equal(batchSize, batches.Last().Count());
         }
 
+        [Fact]
+        public void DistinctBy_NullSource() {
+
+            // Arrange
+
+            IEnumerable<int> source = null;
+            Func<int, int> keySelector = item => item;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => source.DistinctBy(keySelector).ToList()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void DistinctBy_NullKeySelector() {
+
+            // Arrange
+
+            IEnumerable<int> source = new [] { 1, 4, 6, 8 };
+            Func<int, string> keySelector = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => source.DistinctBy(keySelector).ToList()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void DistinctBy_DoesNothingOnEmpty() {
+
+            // Arrange
+
+            IEnumerable<string> source = new string[0];
+
+            // Act
+
+            var results = source.DistinctBy(item => item).ToList();
+
+            // Assert
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void DistinctBy_ConsidersNullItemsDistinctFromNullKeys() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "biz", null, "foo", "bar" };
+            Func<string, string> keySelector = item => item == "foo" ? null : item;
+
+            // Act
+
+            var results = source.DistinctBy(keySelector).ToList();
+
+            // Assert
+
+            Assert.Equal(new [] { "biz", null, "foo", "bar" }, results);
+        }
+
+        [Fact]
+        public void DistinctBy_ConsidersNullItemsEqualKeys() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "biz", null, null, "bar", null };
+            Func<string, string> keySelector = item => item == "foo" ? null : item;
+
+            // Act
+
+            var results = source.DistinctBy(keySelector).ToList();
+
+            // Assert
+
+            Assert.Equal(new [] { "biz", null, "bar" }, results);
+        }
+
+        [Fact]
+        public void DistinctBy_ConsidersNullKeysEqual() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "biz", "FOO", "foo", "FUN", "bar" };
+            Func<string, string> keySelector = item => item[0] == 'F' ? null : item;
+
+            // Act
+
+            var results = source.DistinctBy(keySelector).ToList();
+
+            // Assert
+
+            Assert.Equal(new [] { "biz", "FOO", "foo", "bar" }, results);
+        }
+
+        [Fact]
+        public void DistinctBy_MaintainsOrderWhenNoMatches() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "FOO", "Foo", "FoO" };
+
+            // Act
+
+            var results = source.DistinctBy(item => item).ToList();
+
+            // Assert
+
+            Assert.Equal(source, results);
+        }
+
+        [Fact]
+        public void DistinctBy_MaintainsOrderWithMatches() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "cow", "FOO", "Foo", "moon", "FoO", "bar" };
+
+            // Act
+
+            var results = source.DistinctBy(item => item.ToLower()).ToList();
+
+            // Assert
+
+            Assert.Equal(new [] { "cow", "FOO", "moon", "bar" }, results);
+        }
+
+        [Fact]
+        public void DistinctBy_PreservesOriginalValues() {
+
+            // Arrange
+
+            IEnumerable<string> source = new [] { "FOO", "Foo", "FoO" };
+
+            // Act
+
+            var results = source.DistinctBy(item => item.ToLower()).ToList();
+
+            // Assert
+
+            var result = Assert.Single(results);
+            Assert.Contains(result, source);
+        }
+
         private class SequenceEqualityComparer<T> : IEqualityComparer<IEnumerable<T>> {
 
             public int GetHashCode(IEnumerable<T> sequence) {


### PR DESCRIPTION
Adds a `DistinctBy` implementation for use downstream.